### PR TITLE
fix: make the class compliant with php 7.4+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "softcreatr/jsonpath",
   "description": "JSONPath implementation for parsing, searching and flattening arrays",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "license": "MIT",
   "authors": [
     {
@@ -54,6 +54,7 @@
   },
   "support": {
     "email": "hello@1-2.dev",
+    "forum": "https://github.com/SoftCreatR/JSONPath/discussions",
     "issues": "https://github.com/SoftCreatR/JSONPath/issues",
     "source": "https://github.com/SoftCreatR/JSONPath"
   }

--- a/src/AccessHelper.php
+++ b/src/AccessHelper.php
@@ -59,8 +59,12 @@ class AccessHelper
             $key = abs($key);
         }
 
-        if (is_array($collection) || $collection instanceof ArrayAccess) {
+        if (is_array($collection)) {
             return array_key_exists($key, $collection);
+        }
+        
+        if ($collection instanceof ArrayAccess) {
+            return $collection->offsetExists($key);
         }
 
         if (is_object($collection)) {
@@ -88,6 +92,8 @@ class AccessHelper
             $return = $collection->__get($key);
         } elseif (is_object($collection) && !$collection instanceof ArrayAccess) {
             $return = $collection->$key;
+        } elseif ($collection instanceof ArrayAccess) {
+            $return = $collection->offsetGet($key);
         } elseif (is_array($collection)) {
             if (is_int($key) && $key < 0) {
                 $return = array_slice($collection, $key, 1, false)[0];
@@ -147,6 +153,10 @@ class AccessHelper
         if (is_object($collection) && !$collection instanceof ArrayAccess) {
             return $collection->$key = $value;
         }
+        
+        if ($collection instanceof ArrayAccess) {
+            return $collection->offsetSet($key, $value);
+        }
 
         return $collection[$key] = $value;
     }
@@ -158,7 +168,13 @@ class AccessHelper
     {
         if (is_object($collection) && !$collection instanceof ArrayAccess) {
             unset($collection->$key);
-        } else {
+        }
+        
+        if ($collection instanceof ArrayAccess) {
+            $collection->offsetUnset($key);
+        }
+        
+        if (is_array($collection)) {
             unset($collection[$key]);
         }
     }

--- a/src/AccessHelper.php
+++ b/src/AccessHelper.php
@@ -62,7 +62,7 @@ class AccessHelper
         if (is_array($collection)) {
             return array_key_exists($key, $collection);
         }
-        
+
         if ($collection instanceof ArrayAccess) {
             return $collection->offsetExists($key);
         }
@@ -153,7 +153,7 @@ class AccessHelper
         if (is_object($collection) && !$collection instanceof ArrayAccess) {
             return $collection->$key = $value;
         }
-        
+
         if ($collection instanceof ArrayAccess) {
             return $collection->offsetSet($key, $value);
         }
@@ -169,11 +169,11 @@ class AccessHelper
         if (is_object($collection) && !$collection instanceof ArrayAccess) {
             unset($collection->$key);
         }
-        
+
         if ($collection instanceof ArrayAccess) {
             $collection->offsetUnset($key);
         }
-        
+
         if (is_array($collection)) {
             unset($collection[$key]);
         }

--- a/tests/JSONPathArrayTest.php
+++ b/tests/JSONPathArrayTest.php
@@ -10,15 +10,15 @@ declare(strict_types=1);
 
 namespace Flow\JSONPath\Test;
 
-use ArrayObject;
 use Exception;
 use Flow\JSONPath\JSONPath;
 use Flow\JSONPath\Test\Traits\TestDataTrait;
 use PHPUnit\Framework\TestCase;
 
 use function is_array;
+use function random_int;
 
-class JSONPathArrayAccessTest extends TestCase
+class JSONPathArrayTest extends TestCase
 {
     use TestDataTrait;
 
@@ -27,8 +27,7 @@ class JSONPathArrayAccessTest extends TestCase
      */
     public function testChaining(): void
     {
-        $container = new ArrayObject($this->getData('conferences'));
-        $jsonPath = new JSONPath($container);
+        $jsonPath = (new JSONPath($this->getData('conferences')));
 
         $teams = $jsonPath
             ->find('.conferences.*')
@@ -56,9 +55,9 @@ class JSONPathArrayAccessTest extends TestCase
      */
     public function testIterating(): void
     {
-        $container = new ArrayObject($this->getData('conferences'));
+        $data = $this->getData('conferences');
 
-        $conferences = (new JSONPath($container))
+        $conferences = (new JSONPath($data))
             ->find('.conferences.*');
 
         $names = [];
@@ -76,14 +75,11 @@ class JSONPathArrayAccessTest extends TestCase
     }
 
     /**
-     * @param bool $asArray
-     * @testWith [false]
-     *           [true]
+     * @throws Exception
      */
-    public function testDifferentStylesOfAccess(bool $asArray): void
+    public function testDifferentStylesOfAccess(): void
     {
-        $container = new ArrayObject($this->getData('conferences', $asArray));
-        $data = new JSONPath($container);
+        $data = (new JSONPath($this->getData('conferences', random_int(0, 1))));
 
         self::assertArrayHasKey('conferences', $data);
 
@@ -94,14 +90,5 @@ class JSONPathArrayAccessTest extends TestCase
         } else {
             self::assertEquals('Western Conference', $conferences[0]->name);
         }
-    }
-
-    public function testUpdate(): void
-    {
-        $container = new ArrayObject($this->getData('conferences'));
-        $data = new JSONPath($container);
-
-        $data->offsetSet('name', 'Major League Football');
-        self::assertEquals('Major League Football', $data->name);
     }
 }


### PR DESCRIPTION
since php 7.4, usage of `array_key_exists` has been deprecated (even denied) on object (`ArrayAccess` included).
this change is designed to address this specific case and convert all usage of ArrayAccess instance to base method (to prevent future conflicts of such thing)

sourcing error trace :
```
ErrorException: array_key_exists(): Using array_key_exists() on objects is deprecated. Use isset() or property_exists() instead in /var/www/seat4/vendor/softcreatr/jsonpath/src/AccessHelper.php:68
Stack trace:
#0 /var/www/seat4/vendor/softcreatr/jsonpath/src/AccessHelper.php(68): Illuminate\Foundation\Bootstrap\HandleExceptions->handleError()
#1 /var/www/seat4/vendor/softcreatr/jsonpath/src/Filters/IndexFilter.php(33): Flow\JSONPath\AccessHelper::keyExists()
#2 /var/www/seat4/vendor/softcreatr/jsonpath/src/JSONPath.php(77): Flow\JSONPath\Filters\IndexFilter->filter()
#3 /var/www/seat4/vendor/eveseat/eveapi/src/Mapping/DataMapping.php(65): Flow\JSONPath\JSONPath->find()
#4 /var/www/seat4/vendor/eveseat/eveapi/src/Jobs/Calendar/Detail.php(97): Seat\Eveapi\Mapping\DataMapping::make()
#5 /var/www/seat4/vendor/laravel/framework/src/Illuminate/Support/Traits/EnumeratesValues.php(176): Seat\Eveapi\Jobs\Calendar\Detail->Seat\Eveapi\Jobs\Calendar\{closure}()
#6 /var/www/seat4/vendor/eveseat/eveapi/src/Jobs/Calendar/Detail.php(111): Illuminate\Support\Collection->each()
#7 /var/www/seat4/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(36): Seat\Eveapi\Jobs\Calendar\Detail->handle()
```

[official documentation](https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.array-key-exists-objects)

# 🔀 Pull Request

## What does this PR do?

since php 7.4, usage of `array_key_exists` has been deprecated (even denied) on object (`ArrayAccess` included).
this change is designed to address this specific case and convert all usage of ArrayAccess instance to its base methods (to prevent any similar conflict in futur core refactor)

## Test Plan

- deploy any php version lower than php 7.4
- create a simple `ArrayObject` build over a json result
- try to retrieve any value from it using the library -> pass

- deploy any php version upper or equal to 7.4
- create a simple `ArrayObject` build over a json result
- try to retrieve any value from it using the library -> getting an ErrorException

- apply fix
- redo the test
- pass

```
$json = '{"date": "2016-06-26T21:00:00Z","duration": 60,"event_id": 1386435,"importance": 1,"owner_id": 1,"owner_name": "EVE System","owner_type": "eve_server","response": "Undecided","text": "o7: The EVE Online Show features latest developer news, fast paced action, community overviews and a lot more with CCP Guard and CCP Mimic. Join the thrilling o7 live broadcast at 20:00 EVE time (=UTC) on <a href=\"http://www.twitch.tv/ccp\">EVE TV</a>. Don\'t miss it!","title": "o7 The EVE Online Show"}';
$array = new ArrayObject(json_decode($json, true), ArrayObject::ARRAY_AS_PROPS);

$json_path = new \Flow\JSONPath\JSONPath($array);

// get date value - expected `2016-06-26T21:00:00Z`
$value = $json_path->find('date')->first();

// set date value
$json_path->offsetSet('date', 'test')

// get date value - expected `test`
$value = $json_path->find('date')->first();

```