### PR TITLE
remove phpunit from conflicting packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,6 @@
   "replace": {
     "flow/jsonpath": "*"
   },
-  "conflict": {
-    "phpunit/phpunit": "<7.0 || >= 10.0"
-  },
   "require-dev": {
     "phpunit/phpunit": ">=7.0",
     "roave/security-advisories": "dev-master",


### PR DESCRIPTION
`conflict` is used to mention conflicting production packages, not dev packages.
From what I can tell, you are not exposing a production feature related to PHPUnit.

Keeping it like it is right now doesn't allow installing your package in another system where dev requiements would have lower than 7 version of phpunit and I think it's an artificial conflict that should not exist.
