### PR TITLE
[BUG-69] fixed in clause filter

### DIFF
--- a/src/Filters/QueryMatchFilter.php
+++ b/src/Filters/QueryMatchFilter.php
@@ -56,7 +56,7 @@ class QueryMatchFilter extends AbstractFilter
                 $comparisonValue = preg_replace('/^[\'"]/', '', $comparisonValue);
                 $comparisonValue = preg_replace('/[\'"]$/', '', $comparisonValue);
                 $comparisonValue = preg_replace('/[\'"],[ ]*[\'"]/', ',', $comparisonValue);
-                $comparisonValue = explode(",", $comparisonValue);
+                $comparisonValue = array_map('trim', explode(",", $comparisonValue));
             } else {
                 $comparisonValue = preg_replace('/^[\'"]/', '', $comparisonValue);
                 $comparisonValue = preg_replace('/[\'"]$/', '', $comparisonValue);
@@ -113,14 +113,14 @@ class QueryMatchFilter extends AbstractFilter
                     $return[] = $value;
                 }
 
-                if ($operator === 'in' && is_array($comparisonValue) && in_array($value1, $comparisonValue, true)) {
+                if ($operator === 'in' && is_array($comparisonValue) && in_array($value1, $comparisonValue)) {
                     $return[] = $value;
                 }
 
                 if (
                     ($operator === 'nin' || $operator === '!in') &&
                     is_array($comparisonValue) &&
-                    !in_array($value1, $comparisonValue, true)
+                    !in_array($value1, $comparisonValue)
                 ) {
                     $return[] = $value;
                 }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -1234,7 +1234,7 @@ class QueryTest extends TestCase
                 'filter_expression_with_in_array_of_values',
                 '$[?(@.d in [2, 3])]',
                 '[{"d":1},{"d":2},{"d":1},{"d":3},{"d":4}]',
-                ''
+                '[{"d":2},{"d":3}]'
             ],
             [ // data set #181 - unknown consensus
                 'filter_expression_with_in_current_object',


### PR DESCRIPTION
+ added trim to explode to support both 1,2,3 and 1, 2, 3 inputs
+ dropped in_array strict equality check to be in line with the other
  standard equality checks such as (== and !=)

Resolves #69 