### PR TITLE
Fix php81 deprecated warnings

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -22,15 +22,15 @@ jobs:
     strategy:
       matrix:
         php: [ '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
-    continue-on-error: ${{ matrix.php == '8.1' }}
+    #continue-on-error: ${{ matrix.php == '8.1' }}
     name: PHP ${{ matrix.php }} Test
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2.4.0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@2.11.0
+        uses: shivammathur/setup-php@2.16.0
         with:
           php-version: ${{ matrix.php }}
           extensions: json

--- a/src/JSONPath.php
+++ b/src/JSONPath.php
@@ -210,7 +210,7 @@ class JSONPath implements ArrayAccess, Iterator, JsonSerializable, Countable
     /**
      * @inheritDoc
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         $value = AccessHelper::getValue($this->data, $offset);
 
@@ -250,7 +250,7 @@ class JSONPath implements ArrayAccess, Iterator, JsonSerializable, Countable
     /**
      * @inheritDoc
      */
-    public function current()
+    public function current(): mixed
     {
         $value = current($this->data);
 
@@ -268,7 +268,7 @@ class JSONPath implements ArrayAccess, Iterator, JsonSerializable, Countable
     /**
      * @inheritDoc
      */
-    public function key()
+    public function key(): mixed
     {
         return key($this->data);
     }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

-->

# 🔀 Pull Request

## What does this PR do?
Fix deprecated warnings for PHP 8.1:

```
Deprecated: Return type of Flow\JSONPath\JSONPath::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
Exception:
ErrorException: Deprecated: Return type of Flow\JSONPath\JSONPath::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /www/foe/libs/external/softcreatr/jsonpath/src/JSONPath.php:271
```

## Test Plan
No automated test plan only manual testing done.

## Related PRs and Issues
No related PRs or Issues
