### PR TITLE
:package: Resolve `symfony/error-handler` and PHP 8.1 deprecations

### DIFF
--- a/src/JSONPath.php
+++ b/src/JSONPath.php
@@ -209,7 +209,9 @@ class JSONPath implements ArrayAccess, Iterator, JsonSerializable, Countable
 
     /**
      * @inheritDoc
+     * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $value = AccessHelper::getValue($this->data, $offset);
@@ -249,7 +251,9 @@ class JSONPath implements ArrayAccess, Iterator, JsonSerializable, Countable
 
     /**
      * @inheritDoc
+     * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $value = current($this->data);
@@ -267,7 +271,9 @@ class JSONPath implements ArrayAccess, Iterator, JsonSerializable, Countable
 
     /**
      * @inheritDoc
+     * @return int|string|null
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->data);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

-->

# 🔀 Pull Request

## What does this PR do?

Resolves PHP 8.1 and `symfony/error-handler` deprecations:

> PHP Deprecated:  Return type of Flow\JSONPath\JSONPath::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /.../vendor/softcreatr/jsonpath/src/JSONPath.php on line 213

> PHP message: PHP Deprecated:  Return type of Flow\JSONPath\JSONPath::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /.../vendor/softcreatr/jsonpath/src/JSONPath.php on line 253

> PHP message: PHP Deprecated:  Return type of Flow\JSONPath\JSONPath::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /.../vendor/softcreatr/jsonpath/src/JSONPath.php on line 271


## Test Plan

Didn't test it yet, but used the same changes previously with other packages and internal code with no errors.
Probably enough to run code with PHP 8.1 with enabled error reporting (optional - with enabled `symfony/error-handler`) and check that there is no deprecations.

## Related PRs and Issues

n/a