### PR TITLE
Handle multi-level JSON with objects and arrays

### DIFF
--- a/src/AccessHelper.php
+++ b/src/AccessHelper.php
@@ -145,7 +145,7 @@ class AccessHelper
     /**
      * @throws JSONPathException
      */
-    public static function arrayValues(array|ArrayAccess $collection): array|ArrayAccess
+    public static function arrayValues(array|object $collection): array|ArrayAccess
     {
         if (\is_array($collection)) {
             return \array_values($collection);

--- a/src/Filters/RecursiveFilter.php
+++ b/src/Filters/RecursiveFilter.php
@@ -29,9 +29,9 @@ class RecursiveFilter extends AbstractFilter
     /**
      * @throws JSONPathException
      */
-    private function recurse(array &$result, array|ArrayAccess $data): void
+    private function recurse(array &$result, array|object $data): void
     {
-        $result[] = $data;
+        $result[] = (array)$data;
 
         if (AccessHelper::isCollectionType($data)) {
             foreach (AccessHelper::arrayValues($data) as $value) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

-->

# 🔀 Pull Request

## What does this PR do?

I am using JSONPath with a large and complex JSON file. PHP's json_decode creates a PHP variable that has both arrays and, at lower levels, objects.

I ran into errors creating new JSONPath object. It would be fine with arrays but would return an error when it encountered nested objects. I think this issue is coming up now because of the stricter enforcement of data types in PHP 8.

I made a few minor changes and everything has been working well for the past few months.

## Test Plan

The code has been running without error on a busy site since mid-December.

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)
