### PR TITLE
Change getData() so that it can be mixed instead of array

### DIFF
--- a/src/JSONPath.php
+++ b/src/JSONPath.php
@@ -138,7 +138,7 @@ class JSONPath implements ArrayAccess, Iterator, JsonSerializable, Countable
         return $tokens;
     }
 
-    public function getData(): array
+    public function getData(): mixed
     {
         return $this->data;
     }


### PR DESCRIPTION
# 🔀 Pull Request

## What does this PR do?

The constructor itself allows `$data` to be mixed and the functions in AccessHelper has various conditional statements to process the data depending on whether it is an array or an implementation of `ArrayAccess`. However, `getData()` is explicitly typed to return an array which means any attempts to get the source object after creating a `JSONPath` of it will cause a `TypeError` to be raised. Changing `getData()` to return mixed instead of array will help fix this inconsistency.

Thank you for reviewing and considering this change.

## Test Plan

https://github.com/SoftCreatR/JSONPath/blob/3a6108aa78e4944ea7d8dd846f9ae75a080b007b/tests/JSONPathArrayAccessTest.php#L27-L30

```Diff
diff --git a/tests/JSONPathArrayAccessTest.php b/tests/JSONPathArrayAccessTest.php
index 118b2aa..6066e16 100644
--- a/tests/JSONPathArrayAccessTest.php
+++ b/tests/JSONPathArrayAccessTest.php
@@ -28,6 +28,7 @@ class JSONPathArrayAccessTest extends TestCase
     {
         $container = new ArrayObject($this->getData('conferences'));
         $jsonPath = new JSONPath($container);
+        $jsonPath->getData();
 
         $teams = $jsonPath
             ->find('.conferences.*')
```
If you just add that one line the test will no longer run. This demonstrates the issue that I have described above where you can create a `JSONPath` but then calling `getData()` again to retrieve the original content will fail.
```
1) Flow\JSONPath\Test\JSONPathArrayAccessTest::testChaining
TypeError: Flow\JSONPath\JSONPath::getData(): Return value must be of type array, ArrayObject returned

/app/src/JSONPath.php:143
/app/tests/JSONPathArrayAccessTest.php:31
```

## Related PRs and Issues

None that I am aware of.