### PR TITLE
Fixed: ignore whitespace after comparison in filter expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.10.1
+- Fixed ignore whitespace after comparison value in filter expression
+
 ### 0.10.0
 - Fixed query/selector Filter Expression With Current Object
 - Fixed query/selector Filter Expression With Different Grouped Operators

--- a/src/Filters/QueryMatchFilter.php
+++ b/src/Filters/QueryMatchFilter.php
@@ -28,7 +28,7 @@ class QueryMatchFilter extends AbstractFilter
 
     protected const MATCH_QUERY_OPERATORS = '
       (@\.(?<key>[^\s<>!=]+)|@\[["\']?(?<keySquare>.*?)["\']?\]|(?<node>@)|(%group(?<group>\d+)%))
-      (\s*(?<operator>==|=~|=|<>|!==|!=|>=|<=|>|<|in|!in|nin)\s*(?<comparisonValue>.+?(?=(&&|$|\|\||%))))?
+      (\s*(?<operator>==|=~|=|<>|!==|!=|>=|<=|>|<|in|!in|nin)\s*(?<comparisonValue>.+?(?=\s*(?:&&|$|\|\||%))))?
       (\s*(?<logicalandor>&&|\|\|)\s*)?
     ';
 

--- a/tests/JSONPathTest.php
+++ b/tests/JSONPathTest.php
@@ -325,6 +325,21 @@ class JSONPathTest extends TestCase
     }
 
     /**
+     * $..books[?(@.category=="fiction"  &&  @.author ==  \'Evelyn Waugh\')].title'
+     * Filter books that are in the "..." category and have an author equal to "..."
+     *
+     * @throws JSONPathException|JsonException
+     */
+    public function testQueryMatchWhitespaceIgnored(): void
+    {
+        // Additional spaces in filter string are intended to be there
+        $result = (new JSONPath($this->getData('example')))
+            ->find('$..books[?(    @.category=="fiction"  &&  @.author ==  \'Evelyn Waugh\'  )].title');
+
+        self::assertEquals('Sword of Honour', $result[0]);
+    }
+
+    /**
      * $..books[?(@.author = 1)]
      * Filter books that have a title equal to "..."
      *


### PR DESCRIPTION
# 🔀 Pull Request

## What does this PR do?

White space after the comparator value was consumed by the regex leading to invalid decoding of strings surrounded by single quotes.

This adds the optional whitespace to the positive lookahead. Additionally the lookahead match group is made non-capturing as it serves no purpose in further processing.

## Test Plan

An additional test testQueryMatchWhitespaceIgnored was added to tests/JSONPathTest.php which has a filter string with deliberate additional whitespace added around the query.

## Related PRs and Issues

I did not open an issue ticket for this issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Filter expressions now handle additional whitespace around logical operators more effectively, ensuring more reliable and accurate query results.
  
- **Documentation**
	- Internal release notes have been updated to version 0.10.1.

- **Tests**
	- Added automated tests to confirm that filters correctly process expressions with extra spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->