### PR TITLE
Fix deprecation warning on PHP 8.5

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -23,6 +23,7 @@ jobs:
         - '8.2'
         - '8.3'
         - '8.4'
+        - '8.5'
     continue-on-error: ${{ matrix.php == '8.4' }}
     name: PHP ${{ matrix.php }} Test
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "source": "https://github.com/SoftCreatR/JSONPath"
   },
   "require": {
-    "php": "8.1 - 8.4",
+    "php": "8.1 - 8.5",
     "ext-json": "*"
   },
   "require-dev": {

--- a/src/AccessHelper.php
+++ b/src/AccessHelper.php
@@ -37,7 +37,7 @@ class AccessHelper
         }
 
         if (\is_array($collection)) {
-            return \array_key_exists($key, $collection);
+            return \array_key_exists($key ?? '', $collection);
         }
 
         if ($collection instanceof ArrayAccess) {

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -102,7 +102,7 @@ class QueryTest extends TestCase
                     );
                 }
             }
-        } catch (JSONPathException | RuntimeException $e) {
+        } catch (JSONPathException|RuntimeException $e) {
             if (!\in_array($id, self::$baselineFailedQueries, true)) {
                 throw new RuntimeException(
                     $e->getMessage() . "\nQuery: {$query}\n\nMore information: {$url}",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

-->

# 🔀 Pull Request

## What does this PR do?

Fix deprecation warning when running unit tests on PHP 8.5.

This was the only warning that popped up.

Null coalescing operator `??` was added in PHP 7.0, so there are no backwards compatibility issues. 

- https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.null-coalesce-op

## Test Plan

I enabled workflow to run tests on PHP 8.5.

### Output before

```
$ php8.5 vendor/bin/phpunit --display-all-issues
PHPUnit 12.4.4 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.5.0
Configuration: /home/mpesari/git/SoftCreatR/JSONPath/phpunit.xml.dist

...............................................................  63 / 329 ( 19%)
............................................................... 126 / 329 ( 38%)
............................................................... 189 / 329 ( 57%)
.....................................................D......... 252 / 329 ( 76%)
............................................................... 315 / 329 ( 95%)
..............                                                  329 / 329 (100%)

Time: 00:00.051, Memory: 18.00 MB

1 test triggered 1 PHP deprecation:

1) /home/mpesari/git/SoftCreatR/JSONPath/src/AccessHelper.php:40
Using null as the key parameter for array_key_exists() is deprecated, use an empty string instead

Triggered by:

* Flow\JSONPath\Test\QueryTest::testQueries#149 (4 times)
  /home/mpesari/git/SoftCreatR/JSONPath/tests/QueryTest.php:42

OK, but there were issues!
Tests: 329, Assertions: 610, Deprecations: 1.
```

### Output after

```
$ php8.5 vendor/bin/phpunit --display-all-issues
PHPUnit 12.4.4 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.5.0
Configuration: /home/mpesari/git/SoftCreatR/JSONPath/phpunit.xml.dist

...............................................................  63 / 329 ( 19%)
............................................................... 126 / 329 ( 38%)
............................................................... 189 / 329 ( 57%)
............................................................... 252 / 329 ( 76%)
............................................................... 315 / 329 ( 95%)
..............                                                  329 / 329 (100%)

Time: 00:00.052, Memory: 18.00 MB

OK (329 tests, 610 assertions)
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added PHP 8.5 to automated testing and compatibility metadata.

* **Bug Fixes**
  * Adjusted collection lookup behavior so null keys are treated as an empty-string fallback.

* **Tests**
  * Minor formatting cleanup in tests (no behavior changes).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->